### PR TITLE
Update kube-rbac-proxy image

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -10752,7 +10752,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/charts/k6-operator/README.md
+++ b/charts/k6-operator/README.md
@@ -28,7 +28,7 @@ Kubernetes: `>=1.16.0-0`
 | authProxy.enabled | bool | `true` | enables the protection of /metrics endpoint. (https://github.com/brancz/kube-rbac-proxy) |
 | authProxy.image.name | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` | rbac-proxy image name |
 | authProxy.image.pullPolicy | string | `"IfNotPresent"` | pull policy for the image can be Always, Never, IfNotPresent (default: IfNotPresent) |
-| authProxy.image.tag | string | `"v0.8.0"` | rbac-proxy image tag |
+| authProxy.image.tag | string | `"v0.15.0"` | rbac-proxy image tag |
 | authProxy.livenessProbe | object | `{}` | Liveness probe in Probe format |
 | authProxy.readinessProbe | object | `{}` | Readiness probe in Probe format |
 | authProxy.resources | object | `{}` | rbac-proxy resource limitation/request |

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -33,6 +33,19 @@ patchesStrategicMerge:
 # 'CERTMANAGER' needs to be enabled to use ca injection
 # - webhookcainjection_patch.yaml
 
+patches:
+- patch: |-
+    kind: not-important
+    metadata:
+      name: not-important
+    spec: 
+      template:
+        spec:
+          nodeSelector:
+            purpose: k6-operator
+  target:
+    kind: (StatefulSet|Deployment|Job)
+   
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
The kube-rbac-proxy image was using an old image built on an out-of-support version of Debian. This PR updates the image version to the latest available version. 